### PR TITLE
Don't allow left-0-padded numbers

### DIFF
--- a/example.js
+++ b/example.js
@@ -10,7 +10,7 @@ console.log('\ntestInteger:                   ' + testInteger);
 console.log('JSON.parse(testInteger):       ' + JSON.stringify(JSON.parse(testInteger)));
 console.log('bignumJSON.parse(testInteger): ' + bignumJSON.stringify(bignumJSON.parse(testInteger)));
 
-var testBogusInt = '{"hello":8.}'
+var testBogusInt = '{"hello":8.}';
 console.log('\ntestBogusInt:                  ' + testBogusInt);
 
 var s;
@@ -32,3 +32,22 @@ console.log('bignumJSON.parse(testBogusInt): ' + s);
 
 s = bignumJSON.parse('{"test-NaN":NaN}');
 console.log('bignumJSON.parse(nan): ', s);
+
+var test0Padding = '{"hello":00}';
+console.log('\ntest0Padding:                  ' + test0Padding);
+
+try {
+  s = JSON.stringify(JSON.parse(test0Padding));
+} catch (e) {
+  console.log(e);
+  s = e.toString();
+}
+console.log('JSON.parse(test0Padding):       ' +  s);
+
+try {
+  s = bignumJSON.stringify(bignumJSON.parse(test0Padding, undefined, true, true));
+} catch (e) {
+  console.log(e);
+  s = e.toString();
+}
+console.log('bignumJSON.parse(test0Padding):       ' +  s);

--- a/lib/json.js
+++ b/lib/json.js
@@ -333,6 +333,7 @@ exports.parse = (function () {
 // Parse a number value.
 
             var number,
+                decLoc,
                 string = '';
 
             if (ch === '-') {
@@ -370,16 +371,18 @@ exports.parse = (function () {
                 // means JS rounded or truncated number, too big
                 if (number.toString() !== string) {
 
+                    decLoc = string.indexOf('.');
+
                     // The built-in JSON decoder will error out in this case
                     // and so should we
-                    if (string.indexOf('.') === string.length - 1) {
+                    if (decLoc === string.length - 1 || string.match(/^0[0-9]+/)) {
                         if (allowInvalidNumbers) {
                             return string;
                         } else {
                             error("Bad number");
                         }
                     }
-                
+
                     try {
                         return new BigNumber(string);
                     } catch (e) {
@@ -564,7 +567,7 @@ exports.parse = (function () {
 
     return function (source, reviver, _allowDuplicateProperties, _allowInvalidNumbers) {
         var result;
-        
+
         if (_allowDuplicateProperties !== undefined) {
             allowDuplicateProperties = _allowDuplicateProperties;
         }


### PR DESCRIPTION
Another Coldfusion bug here. It will sometimes create JSON with a payload
that has a left-padded 0 on a number. E.g. 00. We want to turn these into
strings if allowInvalidNumber is set to true.
